### PR TITLE
create_template.py: Remove spurious argument in pcbdraw.get_layers()

### DIFF
--- a/scripts/create_template.py
+++ b/scripts/create_template.py
@@ -92,7 +92,7 @@ def plotBottomLayers(board):
             ("cmt", [pcbnew.Cmts_User], process),
             ("edge", [pcbnew.Edge_Cuts], process),
             ("silk", [pcbnew.B_SilkS], process)]
-    elements = pcbdraw.get_layers(board, colors, {}, plotPlan)
+    elements = pcbdraw.get_layers(board, colors, plotPlan)
     elements.attrib["id"] = "KiCAD footprint bottom"
     return elements
 


### PR DESCRIPTION
Does this without the proposed change:

```
Traceback (most recent call last):
  File "C:\Users\Dzarda\Downloads\PcbDraw-Lib-master\scripts\create_template.py", line 210, in <module>
    cli()
  File "C:\Program Files\KiCad\5.99\bin\lib\site-packages\click\core.py", line 1134, in __call__
    return self.main(*args, **kwargs)
  File "C:\Program Files\KiCad\5.99\bin\lib\site-packages\click\core.py", line 1059, in main
    rv = self.invoke(ctx)
  File "C:\Program Files\KiCad\5.99\bin\lib\site-packages\click\core.py", line 1665, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Program Files\KiCad\5.99\bin\lib\site-packages\click\core.py", line 1401, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Program Files\KiCad\5.99\bin\lib\site-packages\click\core.py", line 767, in invoke
    return __callback(*args, **kwargs)
  File "C:\Users\Dzarda\Downloads\PcbDraw-Lib-master\scripts\create_template.py", line 172, in run_board
    g = plotBottomLayers(fBoard)
  File "C:\Users\Dzarda\Downloads\PcbDraw-Lib-master\scripts\create_template.py", line 95, in plotBottomLayers
    elements = pcbdraw.get_layers(board, colors, {}, plotPlan)
TypeError: get_layers() takes 3 positional arguments but 4 were given
```