### PR TITLE
Pin Sockets, Resize script change, and 

### DIFF
--- a/KiCAD-base/Connector_PinSocket_2.54mm
+++ b/KiCAD-base/Connector_PinSocket_2.54mm
@@ -1,0 +1,1 @@
+Pin_Sockets

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x01.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x01.svg
@@ -53,7 +53,7 @@
      inkscape:groupmode="layer"
      id="pin">
     <rect
-       style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4461316"
        height="1.4461316"
@@ -73,5 +73,5 @@
      width="1"
      height="1"
      x="1.3000001"
-     y="1.299933" />
+     y="1.2999337" />
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x02.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x02.svg
@@ -1,22 +1,97 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="5.1399999mm" viewBox="0 0 2.5999999 5.1399999" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x02.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="1.6959035" inkscape:document-units="px" inkscape:current-layer="g13" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="5.1400018mm"
+   viewBox="0 0 2.6000015 5.1400016"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x02.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x03.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x03.svg
@@ -1,26 +1,117 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="7.6799999mm" viewBox="0 0 2.5999999 7.6799999" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x03.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="5.1208074" inkscape:cy="4.4364867" inkscape:document-units="px" inkscape:current-layer="g19" showgrid="false" inkscape:window-width="1916" inkscape:window-height="1040" inkscape:window-x="0" inkscape:window-y="18" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="7.6800017mm"
+   viewBox="0 0 2.6000015 7.6800015"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x03.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x04.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x04.svg
@@ -1,30 +1,137 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="10.22mm" viewBox="0 0 2.6000001 10.22" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x04.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="7.1145701" inkscape:document-units="px" inkscape:current-layer="g25" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="10.220002mm"
+   viewBox="0 0 2.6000015 10.220002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x04.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x05.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x05.svg
@@ -1,34 +1,157 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="12.76mm" viewBox="0 0 2.5999999 12.76" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x05.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="9.8239031" inkscape:document-units="px" inkscape:current-layer="g31" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="12.760002mm"
+   viewBox="0 0 2.6000015 12.760002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x05.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x06.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x06.svg
@@ -1,38 +1,177 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="15.300001mm" viewBox="0 0 2.6000001 15.300001" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x06.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="12.533238" inkscape:document-units="px" inkscape:current-layer="g37" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="15.300002mm"
+   viewBox="0 0 2.6000015 15.300002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x06.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x07.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x07.svg
@@ -1,42 +1,197 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="17.84mm" viewBox="0 0 2.6000001 17.84" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x07.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="15.24257" inkscape:document-units="px" inkscape:current-layer="g43" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="17.840002mm"
+   viewBox="0 0 2.6000015 17.840002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x07.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x08.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x08.svg
@@ -1,46 +1,217 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="20.38mm" viewBox="0 0 2.6000001 20.38" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x08.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="17.951903" inkscape:document-units="px" inkscape:current-layer="g49" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="20.380001mm"
+   viewBox="0 0 2.6000015 20.38"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x08.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x09.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x09.svg
@@ -1,50 +1,237 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="22.920001mm" viewBox="0 0 2.5999999 22.920001" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x09.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="20.661236" inkscape:document-units="px" inkscape:current-layer="g55" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="22.920002mm"
+   viewBox="0 0 2.6000015 22.920001"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x09.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x10.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x10.svg
@@ -1,54 +1,257 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="25.460001mm" viewBox="0 0 2.6000001 25.460001" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x10.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="23.370572" inkscape:document-units="px" inkscape:current-layer="g61" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="25.460001mm"
+   viewBox="0 0 2.6000015 25.46"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x10.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x11.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x11.svg
@@ -1,58 +1,277 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="28mm" viewBox="0 0 2.6000001 28" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x11.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="26.079904" inkscape:document-units="px" inkscape:current-layer="g67" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="28.000002mm"
+   viewBox="0 0 2.6000015 28.000001"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x11.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x12.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x12.svg
@@ -1,62 +1,297 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="30.540001mm" viewBox="0 0 2.6000001 30.540001" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x12.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="28.78924" inkscape:document-units="px" inkscape:current-layer="g73" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="30.540003mm"
+   viewBox="0 0 2.6000015 30.540002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x12.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x13.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x13.svg
@@ -1,66 +1,317 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="33.079999mm" viewBox="0 0 2.5999999 33.079999" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x13.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="31.498571" inkscape:document-units="px" inkscape:current-layer="g79" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="33.080002mm"
+   viewBox="0 0 2.6000015 33.080001"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x13.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x14.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x14.svg
@@ -1,70 +1,337 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="35.620002mm" viewBox="0 0 2.6000001 35.620002" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x14.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="5.1208074" inkscape:cy="34.239155" inkscape:document-units="px" inkscape:current-layer="g85" showgrid="false" inkscape:window-width="1916" inkscape:window-height="1040" inkscape:window-x="0" inkscape:window-y="18" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="35.620003mm"
+   viewBox="0 0 2.6000015 35.620002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x14.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x15.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x15.svg
@@ -1,74 +1,357 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="38.16mm" viewBox="0 0 2.5999999 38.16" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x15.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="36.917237" inkscape:document-units="px" inkscape:current-layer="g91" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="38.160004mm"
+   viewBox="0 0 2.6000015 38.160003"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x15.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x16.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x16.svg
@@ -1,78 +1,377 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="40.7mm" viewBox="0 0 2.6000001 40.7" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x16.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="39.626571" inkscape:document-units="px" inkscape:current-layer="g97" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="40.700001mm"
+   viewBox="0 0 2.6000015 40.7"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x16.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x17.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x17.svg
@@ -1,82 +1,397 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="43.240001mm" viewBox="0 0 2.5999999 43.240001" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x17.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="42.335902" inkscape:document-units="px" inkscape:current-layer="g103" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="43.240002mm"
+   viewBox="0 0 2.6000015 43.24"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x17.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x18.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x18.svg
@@ -1,86 +1,417 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="45.780001mm" viewBox="0 0 2.6000001 45.780001" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x18.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="2.6208074" inkscape:cy="45.045237" inkscape:document-units="px" inkscape:current-layer="g109" showgrid="false" inkscape:window-width="636" inkscape:window-height="1056" inkscape:window-x="476" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="45.780003mm"
+   viewBox="0 0 2.6000015 45.780001"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x18.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x19.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x19.svg
@@ -1,90 +1,437 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="48.320001mm" viewBox="0 0 2.6000001 48.320001" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x19.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="47.75457" inkscape:document-units="px" inkscape:current-layer="g115" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="48.320004mm"
+   viewBox="0 0 2.6000015 48.320002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x19.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x20.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x20.svg
@@ -1,94 +1,457 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="50.860001mm" viewBox="0 0 2.5999999 50.860001" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x20.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="50.463905" inkscape:document-units="px" inkscape:current-layer="g121" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="50.860001mm"
+   viewBox="0 0 2.6000015 50.859999"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x20.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x21.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x21.svg
@@ -1,98 +1,477 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="53.400002mm" viewBox="0 0 2.6000001 53.400002" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x21.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="5.1208074" inkscape:cy="53.204489" inkscape:document-units="px" inkscape:current-layer="g127" showgrid="false" inkscape:window-width="1916" inkscape:window-height="1040" inkscape:window-x="0" inkscape:window-y="18" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="53.400002mm"
+   viewBox="0 0 2.6000015 53.4"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x21.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x22.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x22.svg
@@ -1,102 +1,497 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="55.939969mm" viewBox="0 0 2.5999999 55.939969" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x22.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="55.882539" inkscape:document-units="px" inkscape:current-layer="g133" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="55.940002mm"
+   viewBox="0 0 2.6000015 55.940001"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x22.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x23.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x23.svg
@@ -1,106 +1,517 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="58.479969mm" viewBox="0 0 2.6000001 58.479969" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x23.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="58.591869" inkscape:document-units="px" inkscape:current-layer="g139" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="58.480003mm"
+   viewBox="0 0 2.6000015 58.480002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x23.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x24.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x24.svg
@@ -1,110 +1,537 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="61.01997mm" viewBox="0 0 2.6000001 61.01997" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x24.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="61.30121" inkscape:document-units="px" inkscape:current-layer="g145" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="61.020004mm"
+   viewBox="0 0 2.6000015 61.020003"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x24.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x25.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x25.svg
@@ -1,114 +1,557 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="63.55997mm" viewBox="0 0 2.6000001 63.55997" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x25.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="64.010544" inkscape:document-units="px" inkscape:current-layer="g151" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="63.560001mm"
+   viewBox="0 0 2.6000015 63.56"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x25.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x26.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x26.svg
@@ -1,118 +1,577 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="66.09997mm" viewBox="0 0 2.5999999 66.09997" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x26.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="66.719873" inkscape:document-units="px" inkscape:current-layer="g157" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="66.100006mm"
+   viewBox="0 0 2.6000015 66.100004"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x26.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x27.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x27.svg
@@ -1,122 +1,597 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="68.639971mm" viewBox="0 0 2.5999999 68.639971" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x27.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="69.429207" inkscape:document-units="px" inkscape:current-layer="g163" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="68.639999mm"
+   viewBox="0 0 2.6000015 68.639997"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x27.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x28.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x28.svg
@@ -1,126 +1,617 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="71.179971mm" viewBox="0 0 2.6000001 71.179971" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x28.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="72.138541" inkscape:document-units="px" inkscape:current-layer="g169" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="71.18mm"
+   viewBox="0 0 2.6000015 71.179998"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x28.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x29.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x29.svg
@@ -1,130 +1,637 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="73.719972mm" viewBox="0 0 2.6000001 73.719972" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x29.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="74.847874" inkscape:document-units="px" inkscape:current-layer="g175" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="73.720001mm"
+   viewBox="0 0 2.6000015 73.719999"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x29.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x30.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x30.svg
@@ -1,134 +1,657 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="76.259972mm" viewBox="0 0 2.6000001 76.259972" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x30.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="5.1208074" inkscape:cy="77.588459" inkscape:document-units="px" inkscape:current-layer="g181" showgrid="false" inkscape:window-width="1916" inkscape:window-height="1040" inkscape:window-x="0" inkscape:window-y="18" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="76.260002mm"
+   viewBox="0 0 2.6000015 76.26"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x30.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x31.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x31.svg
@@ -1,138 +1,677 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="78.799972mm" viewBox="0 0 2.5999999 78.799972" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x31.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="80.266538" inkscape:document-units="px" inkscape:current-layer="g187" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="78.800003mm"
+   viewBox="0 0 2.6000015 78.800001"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x31.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x32.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x32.svg
@@ -1,142 +1,697 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="81.339973mm" viewBox="0 0 2.5999999 81.339973" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x32.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="82.975872" inkscape:document-units="px" inkscape:current-layer="g193" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="81.340004mm"
+   viewBox="0 0 2.6000015 81.340002"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x32.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x33.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x33.svg
@@ -1,146 +1,717 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="83.879973mm" viewBox="0 0 2.6000001 83.879973" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x33.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="85.685206" inkscape:document-units="px" inkscape:current-layer="g199" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="83.880005mm"
+   viewBox="0 0 2.6000015 83.880003"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x33.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-969.78226)" id="g199">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect195" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect197" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.280001)"
+     id="g199">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect197"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x34.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x34.svg
@@ -1,150 +1,737 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="86.419974mm" viewBox="0 0 2.6000001 86.419974" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x34.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="5.1208074" inkscape:cy="88.425789" inkscape:document-units="px" inkscape:current-layer="g205" showgrid="false" inkscape:window-width="1916" inkscape:window-height="1040" inkscape:window-x="0" inkscape:window-y="18" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="86.420006mm"
+   viewBox="0 0 2.6000015 86.420003"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x34.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-969.78226)" id="g199">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect195" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect197" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.280001)"
+     id="g199">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect197"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-967.24226)" id="g205">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect201" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect203" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.820001)"
+     id="g205">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect203"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x35.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x35.svg
@@ -1,154 +1,757 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="88.959974mm" viewBox="0 0 2.6000001 88.959974" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x35.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="91.103873" inkscape:document-units="px" inkscape:current-layer="g211" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="88.959999mm"
+   viewBox="0 0 2.6000015 88.959997"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x35.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-969.78226)" id="g199">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect195" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect197" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.280001)"
+     id="g199">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect197"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-967.24226)" id="g205">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect201" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect203" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.820001)"
+     id="g205">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect203"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-964.70226)" id="g211">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect207" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect209" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.360001)"
+     id="g211">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect209"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x36.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x36.svg
@@ -1,158 +1,777 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="91.499967mm" viewBox="0 0 2.5999999 91.499967" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x36.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="93.813204" inkscape:document-units="px" inkscape:current-layer="g217" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="91.5mm"
+   viewBox="0 0 2.6000015 91.499997"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x36.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-969.78226)" id="g199">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect195" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect197" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.280001)"
+     id="g199">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect197"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-967.24226)" id="g205">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect201" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect203" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.820001)"
+     id="g205">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect203"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-964.70226)" id="g211">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect207" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect209" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.360001)"
+     id="g211">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect209"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-962.16226)" id="g217">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect213" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect215" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.900001)"
+     id="g217">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect215"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x37.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x37.svg
@@ -1,162 +1,797 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.5999999mm" height="94.039968mm" viewBox="0 0 2.5999999 94.039968" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x37.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="96.522537" inkscape:document-units="px" inkscape:current-layer="g223" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="94.040001mm"
+   viewBox="0 0 2.6000015 94.039998"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x37.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-969.78226)" id="g199">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect195" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect197" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.280001)"
+     id="g199">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect197"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-967.24226)" id="g205">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect201" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect203" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.820001)"
+     id="g205">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect203"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-964.70226)" id="g211">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect207" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect209" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.360001)"
+     id="g211">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect209"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-962.16226)" id="g217">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect213" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect215" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.900001)"
+     id="g217">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect215"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-959.62226)" id="g223">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect219" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect221" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,91.440001)"
+     id="g223">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect219"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect221"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x38.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x38.svg
@@ -1,166 +1,817 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="96.579968mm" viewBox="0 0 2.6000001 96.579968" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x38.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="99.231871" inkscape:document-units="px" inkscape:current-layer="g229" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="96.580002mm"
+   viewBox="0 0 2.6000015 96.579999"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x38.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-969.78226)" id="g199">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect195" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect197" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.280001)"
+     id="g199">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect197"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-967.24226)" id="g205">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect201" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect203" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.820001)"
+     id="g205">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect203"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-964.70226)" id="g211">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect207" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect209" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.360001)"
+     id="g211">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect209"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-962.16226)" id="g217">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect213" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect215" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.900001)"
+     id="g217">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect215"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-959.62226)" id="g223">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect219" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect221" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,91.440001)"
+     id="g223">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect219"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect221"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-957.08226)" id="g229">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect225" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect227" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,93.980001)"
+     id="g229">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect225"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect227"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x39.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x39.svg
@@ -1,170 +1,837 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="99.119969mm" viewBox="0 0 2.6000001 99.119969" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x39.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="101.9412" inkscape:document-units="px" inkscape:current-layer="g235" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="99.120003mm"
+   viewBox="0 0 2.6000015 99.12"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x39.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-969.78226)" id="g199">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect195" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect197" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.280001)"
+     id="g199">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect197"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-967.24226)" id="g205">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect201" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect203" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.820001)"
+     id="g205">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect203"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-964.70226)" id="g211">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect207" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect209" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.360001)"
+     id="g211">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect209"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-962.16226)" id="g217">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect213" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect215" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.900001)"
+     id="g217">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect215"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-959.62226)" id="g223">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect219" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect221" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,91.440001)"
+     id="g223">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect219"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect221"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-957.08226)" id="g229">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect225" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect227" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,93.980001)"
+     id="g229">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect225"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect227"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-954.54226)" id="g235">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect231" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect233" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,96.520001)"
+     id="g235">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect231"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect233"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x40.svg
+++ b/KiCAD-base/Pin_Headers/Pin_Header_Straight_1x40.svg
@@ -1,174 +1,857 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) --><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="2.6000001mm" height="101.65997mm" viewBox="0 0 2.6000001 101.65997" id="svg4138" version="1.1" inkscape:version="0.92.3 (2405546, 2018-03-11)" sodipodi:docname="Pin_Header_Straight_1x40.svg">
-  <defs id="defs4140"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="256" inkscape:cx="3.2458074" inkscape:cy="104.65054" inkscape:document-units="px" inkscape:current-layer="g241" showgrid="false" inkscape:window-width="956" inkscape:window-height="1056" inkscape:window-x="960" inkscape:window-y="0" inkscape:window-maximized="0"/>
-  <metadata id="metadata4143">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000016mm"
+   height="101.66mm"
+   viewBox="0 0 2.6000015 101.66"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="Pin_Header_Straight_1x40.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="8.4375"
+     inkscape:cy="2.609375"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="1417"
+     inkscape:window-height="1088"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata4143">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" id="pin" transform="translate(1.3,-1051.0622)">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect4686" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect156830" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect156830"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <rect style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98299998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="origin" width="1" height="1" x="1.3000001" y="1.2999307"/>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1048.5222)" id="g13">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect9" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect11" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.3000001"
+     y="1.2999337" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5400008)"
+     id="g13">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect11"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1045.9822)" id="g19">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect15" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect17" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0800008)"
+     id="g19">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect17"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1043.4422)" id="g25">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect21" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect23" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6200008)"
+     id="g25">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect23"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1040.9022)" id="g31">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect27" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect29" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.160001)"
+     id="g31">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect29"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1038.3622)" id="g37">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect33" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect35" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.700001)"
+     id="g37">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect35"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1035.8222)" id="g43">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect39" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect41" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.240001)"
+     id="g43">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect41"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1033.2822)" id="g49">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect45" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect47" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.780001)"
+     id="g49">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect47"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1030.7422)" id="g55">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect51" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect53" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.320001)"
+     id="g55">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect53"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1028.2022)" id="g61">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect57" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect59" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.860001)"
+     id="g61">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect59"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1025.6622)" id="g67">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect63" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect65" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.400001)"
+     id="g67">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect65"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1023.1222)" id="g73">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect69" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect71" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.940001)"
+     id="g73">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect71"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1020.5822)" id="g79">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect75" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect77" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.480001)"
+     id="g79">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect77"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1018.0422)" id="g85">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect81" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect83" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.020001)"
+     id="g85">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect83"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1015.5022)" id="g91">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect87" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect89" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.560001)"
+     id="g91">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect89"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1012.9622)" id="g97">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect93" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect95" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.100001)"
+     id="g97">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect95"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1010.4222)" id="g103">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect99" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect101" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.640001)"
+     id="g103">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect101"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1007.8822)" id="g109">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect105" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect107" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.180001)"
+     id="g109">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect107"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1005.3422)" id="g115">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect111" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect113" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.720001)"
+     id="g115">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect113"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1002.8022)" id="g121">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect117" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect119" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.260001)"
+     id="g121">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect119"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-1000.2622)" id="g127">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect123" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect125" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.800001)"
+     id="g127">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect125"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-997.72226)" id="g133">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect129" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect131" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.340001)"
+     id="g133">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect131"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-995.18226)" id="g139">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect135" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect137" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.880001)"
+     id="g139">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect137"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-992.64226)" id="g145">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect141" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect143" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.420001)"
+     id="g145">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect143"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-990.10226)" id="g151">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect147" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect149" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.960001)"
+     id="g151">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect149"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-987.56226)" id="g157">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect153" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect155" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.500001)"
+     id="g157">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect155"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-985.02226)" id="g163">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect159" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect161" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.040001)"
+     id="g163">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect161"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-982.48226)" id="g169">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect165" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect167" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.580001)"
+     id="g169">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect167"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-979.94226)" id="g175">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect171" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect173" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.120001)"
+     id="g175">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect173"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-977.40226)" id="g181">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect177" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect179" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.660001)"
+     id="g181">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect179"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-974.86226)" id="g187">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect183" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect185" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.200001)"
+     id="g187">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect185"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-972.32226)" id="g193">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect189" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect191" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.740001)"
+     id="g193">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect191"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-969.78226)" id="g199">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect195" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect197" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.280001)"
+     id="g199">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect197"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-967.24226)" id="g205">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect201" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect203" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.820001)"
+     id="g205">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect203"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-964.70226)" id="g211">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect207" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect209" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.360001)"
+     id="g211">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect209"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-962.16226)" id="g217">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect213" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect215" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.900001)"
+     id="g217">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect215"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-959.62226)" id="g223">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect219" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect221" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,91.440001)"
+     id="g223">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect219"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect221"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-957.08226)" id="g229">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect225" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect227" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,93.980001)"
+     id="g229">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect225"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect227"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-954.54226)" id="g235">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect231" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect233" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,96.520001)"
+     id="g235">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect231"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect233"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
-  <g inkscape:label="Vrstva 1" inkscape:groupmode="layer" transform="translate(1.3,-952.00226)" id="g241">
-    <rect style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15386844;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="rect237" width="1.4461316" height="1.4461316" x="-0.72306579" y="1051.6392"/>
-    <rect y="1052.1041" x="-0.25806209" height="0.51612419" width="0.51612419" id="rect239" style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.12387582;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,99.060001)"
+     id="g241">
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect237"
+       width="1.4461316"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       y="1.0419546"
+       x="1.0419546"
+       height="0.51612419"
+       width="0.51612419"
+       id="rect239"
+       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x01_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x01_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,5 +74,5 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
 </svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x01_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x01_P2.54mm_Vertical.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000624mm"
+   height="2.5999815mm"
+   viewBox="0 0 2.6000623 2.5999815"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x01_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x02_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x02_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x02_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x02_P2.54mm_Vertical.svg
@@ -2,13 +2,13 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="2.6000016mm"
-   height="2.6000016mm"
-   viewBox="0 0 2.6000015 2.6000015"
+   width="2.6000724mm"
+   height="5.1399817mm"
+   viewBox="0 0 2.6000723 5.1399817"
    id="svg4138"
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
-   sodipodi:docname="Pin_Socket_Straight_1x01.svg"
+   sodipodi:docname="PinSocket_1x02_P2.54mm_Vertical.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -25,9 +25,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="64"
-     inkscape:cx="5.9296875"
-     inkscape:cy="4.4140625"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
      inkscape:document-units="px"
      inkscape:current-layer="pin"
      showgrid="false"
@@ -36,7 +36,7 @@
      inkscape:window-x="1920"
      inkscape:window-y="26"
      inkscape:window-maximized="1"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="true" />
   <metadata
      id="metadata4143">
     <rdf:RDF>
@@ -51,11 +51,12 @@
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
-     id="pin">
+     id="pin"
+     transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:0.997551;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
-       width="1.4462125"
+       width="1.4462124"
        height="1.4461316"
        x="0.57693499"
        y="0.57693422" />
@@ -72,6 +73,26 @@
      id="origin"
      width="1"
      height="1"
-     x="1.3000001"
-     y="1.2999322" />
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
 </svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x03_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x03_P2.54mm_Vertical.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="7.6799817mm"
+   viewBox="0 0 2.6000723 7.6799816"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x03_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x03_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x03_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x04_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x04_P2.54mm_Vertical.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="10.219982mm"
+   viewBox="0 0 2.6000723 10.219982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x04_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x04_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x04_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x05_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x05_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x05_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x05_P2.54mm_Vertical.svg
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="12.759982mm"
+   viewBox="0 0 2.6000723 12.759982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x05_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x06_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x06_P2.54mm_Vertical.svg
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="15.299982mm"
+   viewBox="0 0 2.6000723 15.299982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x06_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x06_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x06_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x07_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x07_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x07_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x07_P2.54mm_Vertical.svg
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="17.839983mm"
+   viewBox="0 0 2.6000723 17.839983"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x07_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x08_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x08_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x08_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x08_P2.54mm_Vertical.svg
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="20.379982mm"
+   viewBox="0 0 2.6000723 20.379982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x08_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x09_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x09_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x09_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x09_P2.54mm_Vertical.svg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="22.919983mm"
+   viewBox="0 0 2.6000723 22.919983"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x09_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x10_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x10_P2.54mm_Vertical.svg
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="25.459982mm"
+   viewBox="0 0 2.6000723 25.459981"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x10_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x10_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x10_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x11_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x11_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x11_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x11_P2.54mm_Vertical.svg
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="27.999983mm"
+   viewBox="0 0 2.6000723 27.999982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x11_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x12_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x12_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x12_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x12_P2.54mm_Vertical.svg
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="30.539982mm"
+   viewBox="0 0 2.6000723 30.539981"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x12_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x13_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x13_P2.54mm_Vertical.svg
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="33.079983mm"
+   viewBox="0 0 2.6000723 33.079982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x13_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x13_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x13_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x14_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x14_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x14_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x14_P2.54mm_Vertical.svg
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="35.619984mm"
+   viewBox="0 0 2.6000723 35.619983"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x14_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x15_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x15_P2.54mm_Vertical.svg
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="38.159985mm"
+   viewBox="0 0 2.6000723 38.159984"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x15_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x15_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x15_P2.54mm_Vertical.svg
@@ -3,8 +3,8 @@
 
 <svg
    width="2.6000724mm"
-   height="38.159985mm"
-   viewBox="0 0 2.6000723 38.159984"
+   height="38.159981mm"
+   viewBox="0 0 2.6000723 38.15998"
    id="svg4138"
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x16_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x16_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x16_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x16_P2.54mm_Vertical.svg
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="40.699982mm"
+   viewBox="0 0 2.6000723 40.699981"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x16_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x17_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x17_P2.54mm_Vertical.svg
@@ -1,0 +1,398 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="43.239983mm"
+   viewBox="0 0 2.6000723 43.239982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x17_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x17_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x17_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x18_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x18_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x18_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x18_P2.54mm_Vertical.svg
@@ -1,0 +1,418 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="45.779984mm"
+   viewBox="0 0 2.6000723 45.779983"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x18_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x19_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x19_P2.54mm_Vertical.svg
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="48.319984mm"
+   viewBox="0 0 2.6000723 48.319984"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x19_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x19_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x19_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x1_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x1_P2.54mm_Vertical.svg
@@ -8,7 +8,7 @@
    id="svg4138"
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
-   sodipodi:docname="Pin_Header_Straight_1x01.svg"
+   sodipodi:docname="Pin_Socket_Straight_1x01.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -25,17 +25,17 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="32"
-     inkscape:cx="8.4375"
-     inkscape:cy="2.609375"
+     inkscape:zoom="64"
+     inkscape:cx="5.9296875"
+     inkscape:cy="4.4140625"
      inkscape:document-units="px"
      inkscape:current-layer="pin"
      showgrid="false"
-     inkscape:window-width="1417"
-     inkscape:window-height="1088"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
      inkscape:window-x="1920"
      inkscape:window-y="26"
-     inkscape:window-maximized="0"
+     inkscape:window-maximized="1"
      inkscape:pagecheckerboard="0" />
   <metadata
      id="metadata4143">
@@ -53,19 +53,19 @@
      inkscape:groupmode="layer"
      id="pin">
     <rect
-       style="opacity:0.95;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15387;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:0.95;fill:#141414;fill-opacity:0.997551;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
-       width="1.4461316"
+       width="1.4462125"
        height="1.4461316"
        x="0.57693499"
        y="0.57693422" />
     <rect
-       y="1.0419546"
-       x="1.0419546"
-       height="0.51612419"
-       width="0.51612419"
-       id="rect156830"
-       style="opacity:1;fill:#fcf23a;fill-opacity:1;fill-rule:nonzero;stroke:#eb9d02;stroke-width:0.123876;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
   </g>
   <rect
      style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -73,5 +73,5 @@
      width="1"
      height="1"
      x="1.3000001"
-     y="1.299933" />
+     y="1.2999322" />
 </svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x20_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x20_P2.54mm_Vertical.svg
@@ -1,0 +1,458 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="50.859985mm"
+   viewBox="0 0 2.6000723 50.859984"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x20_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x20_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x20_P2.54mm_Vertical.svg
@@ -3,8 +3,8 @@
 
 <svg
    width="2.6000724mm"
-   height="50.859985mm"
-   viewBox="0 0 2.6000723 50.859984"
+   height="50.859982mm"
+   viewBox="0 0 2.6000723 50.859981"
    id="svg4138"
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x21_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x21_P2.54mm_Vertical.svg
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="53.399982mm"
+   viewBox="0 0 2.6000723 53.399981"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x21_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x21_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x21_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x22_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x22_P2.54mm_Vertical.svg
@@ -1,0 +1,498 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="55.939983mm"
+   viewBox="0 0 2.6000723 55.939982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x22_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x22_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x22_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x23_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x23_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x23_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x23_P2.54mm_Vertical.svg
@@ -1,0 +1,518 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="58.479984mm"
+   viewBox="0 0 2.6000723 58.479983"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x23_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x24_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x24_P2.54mm_Vertical.svg
@@ -3,8 +3,8 @@
 
 <svg
    width="2.6000724mm"
-   height="61.019985mm"
-   viewBox="0 0 2.6000723 61.019984"
+   height="61.019981mm"
+   viewBox="0 0 2.6000723 61.01998"
    id="svg4138"
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x24_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x24_P2.54mm_Vertical.svg
@@ -1,0 +1,538 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="61.019985mm"
+   viewBox="0 0 2.6000723 61.019984"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x24_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x25_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x25_P2.54mm_Vertical.svg
@@ -1,0 +1,558 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="63.559982mm"
+   viewBox="0 0 2.6000723 63.559981"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x25_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x25_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x25_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x26_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x26_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x26_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x26_P2.54mm_Vertical.svg
@@ -1,0 +1,578 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="66.099983mm"
+   viewBox="0 0 2.6000723 66.099982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x26_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x27_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x27_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x27_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x27_P2.54mm_Vertical.svg
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="68.639984mm"
+   viewBox="0 0 2.6000723 68.639983"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x27_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x28_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x28_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x28_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x28_P2.54mm_Vertical.svg
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="71.179985mm"
+   viewBox="0 0 2.6000723 71.179984"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x28_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x29_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x29_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x29_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x29_P2.54mm_Vertical.svg
@@ -1,0 +1,638 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="73.719986mm"
+   viewBox="0 0 2.6000723 73.719985"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x29_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x30_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x30_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x30_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x30_P2.54mm_Vertical.svg
@@ -1,0 +1,658 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="76.259987mm"
+   viewBox="0 0 2.6000723 76.259986"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x30_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x31_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x31_P2.54mm_Vertical.svg
@@ -1,0 +1,678 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="78.799988mm"
+   viewBox="0 0 2.6000723 78.799986"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x31_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x31_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x31_P2.54mm_Vertical.svg
@@ -3,8 +3,8 @@
 
 <svg
    width="2.6000724mm"
-   height="78.799988mm"
-   viewBox="0 0 2.6000723 78.799986"
+   height="78.79998mm"
+   viewBox="0 0 2.6000723 78.799979"
    id="svg4138"
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x32_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x32_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x32_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x32_P2.54mm_Vertical.svg
@@ -1,0 +1,698 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="81.339981mm"
+   viewBox="0 0 2.6000723 81.33998"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x32_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x33_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x33_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"
@@ -701,7 +701,7 @@
      transform="translate(0,81.279991)"
      id="g199">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect195"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x33_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x33_P2.54mm_Vertical.svg
@@ -1,0 +1,718 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="83.879982mm"
+   viewBox="0 0 2.6000723 83.87998"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x33_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.279991)"
+     id="g199">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect197"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x34_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x34_P2.54mm_Vertical.svg
@@ -1,0 +1,738 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="86.419983mm"
+   viewBox="0 0 2.6000723 86.419981"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x34_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.279991)"
+     id="g199">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect197"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.819991)"
+     id="g205">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect203"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x34_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x34_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"
@@ -701,7 +701,7 @@
      transform="translate(0,81.279991)"
      id="g199">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect195"
        width="1.4462124"
        height="1.4461316"
@@ -721,7 +721,7 @@
      transform="translate(0,83.819991)"
      id="g205">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect201"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x35_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x35_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"
@@ -701,7 +701,7 @@
      transform="translate(0,81.279991)"
      id="g199">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect195"
        width="1.4462124"
        height="1.4461316"
@@ -721,7 +721,7 @@
      transform="translate(0,83.819991)"
      id="g205">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect201"
        width="1.4462124"
        height="1.4461316"
@@ -741,7 +741,7 @@
      transform="translate(0,86.359991)"
      id="g211">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect207"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x35_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x35_P2.54mm_Vertical.svg
@@ -1,0 +1,758 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="88.959984mm"
+   viewBox="0 0 2.6000723 88.959982"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x35_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.279991)"
+     id="g199">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect197"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.819991)"
+     id="g205">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect203"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.359991)"
+     id="g211">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect209"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x36_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x36_P2.54mm_Vertical.svg
@@ -1,0 +1,778 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="91.499985mm"
+   viewBox="0 0 2.6000723 91.499983"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x36_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.279991)"
+     id="g199">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect197"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.819991)"
+     id="g205">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect203"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.359991)"
+     id="g211">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect209"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.899991)"
+     id="g217">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect215"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x36_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x36_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"
@@ -701,7 +701,7 @@
      transform="translate(0,81.279991)"
      id="g199">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect195"
        width="1.4462124"
        height="1.4461316"
@@ -721,7 +721,7 @@
      transform="translate(0,83.819991)"
      id="g205">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect201"
        width="1.4462124"
        height="1.4461316"
@@ -741,7 +741,7 @@
      transform="translate(0,86.359991)"
      id="g211">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect207"
        width="1.4462124"
        height="1.4461316"
@@ -761,7 +761,7 @@
      transform="translate(0,88.899991)"
      id="g217">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect213"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x37_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x37_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"
@@ -701,7 +701,7 @@
      transform="translate(0,81.279991)"
      id="g199">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect195"
        width="1.4462124"
        height="1.4461316"
@@ -721,7 +721,7 @@
      transform="translate(0,83.819991)"
      id="g205">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect201"
        width="1.4462124"
        height="1.4461316"
@@ -741,7 +741,7 @@
      transform="translate(0,86.359991)"
      id="g211">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect207"
        width="1.4462124"
        height="1.4461316"
@@ -761,7 +761,7 @@
      transform="translate(0,88.899991)"
      id="g217">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect213"
        width="1.4462124"
        height="1.4461316"
@@ -781,7 +781,7 @@
      transform="translate(0,91.439991)"
      id="g223">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect219"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x37_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x37_P2.54mm_Vertical.svg
@@ -1,0 +1,798 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="94.039986mm"
+   viewBox="0 0 2.6000723 94.039984"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x37_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.279991)"
+     id="g199">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect197"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.819991)"
+     id="g205">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect203"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.359991)"
+     id="g211">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect209"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.899991)"
+     id="g217">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect215"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,91.439991)"
+     id="g223">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect219"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect221"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x38_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x38_P2.54mm_Vertical.svg
@@ -1,0 +1,818 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="96.579987mm"
+   viewBox="0 0 2.6000723 96.579985"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x38_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.279991)"
+     id="g199">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect197"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.819991)"
+     id="g205">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect203"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.359991)"
+     id="g211">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect209"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.899991)"
+     id="g217">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect215"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,91.439991)"
+     id="g223">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect219"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect221"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,93.979991)"
+     id="g229">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect225"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect227"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x38_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x38_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"
@@ -701,7 +701,7 @@
      transform="translate(0,81.279991)"
      id="g199">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect195"
        width="1.4462124"
        height="1.4461316"
@@ -721,7 +721,7 @@
      transform="translate(0,83.819991)"
      id="g205">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect201"
        width="1.4462124"
        height="1.4461316"
@@ -741,7 +741,7 @@
      transform="translate(0,86.359991)"
      id="g211">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect207"
        width="1.4462124"
        height="1.4461316"
@@ -761,7 +761,7 @@
      transform="translate(0,88.899991)"
      id="g217">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect213"
        width="1.4462124"
        height="1.4461316"
@@ -781,7 +781,7 @@
      transform="translate(0,91.439991)"
      id="g223">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect219"
        width="1.4462124"
        height="1.4461316"
@@ -801,7 +801,7 @@
      transform="translate(0,93.979991)"
      id="g229">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect225"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x39_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x39_P2.54mm_Vertical.svg
@@ -1,0 +1,838 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="99.119987mm"
+   viewBox="0 0 2.6000723 99.119986"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x39_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.279991)"
+     id="g199">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect197"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.819991)"
+     id="g205">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect203"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.359991)"
+     id="g211">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect209"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.899991)"
+     id="g217">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect215"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,91.439991)"
+     id="g223">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect219"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect221"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,93.979991)"
+     id="g229">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect225"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect227"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,96.519991)"
+     id="g235">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect231"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect233"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x39_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x39_P2.54mm_Vertical.svg
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"
@@ -701,7 +701,7 @@
      transform="translate(0,81.279991)"
      id="g199">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect195"
        width="1.4462124"
        height="1.4461316"
@@ -721,7 +721,7 @@
      transform="translate(0,83.819991)"
      id="g205">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect201"
        width="1.4462124"
        height="1.4461316"
@@ -741,7 +741,7 @@
      transform="translate(0,86.359991)"
      id="g211">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect207"
        width="1.4462124"
        height="1.4461316"
@@ -761,7 +761,7 @@
      transform="translate(0,88.899991)"
      id="g217">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect213"
        width="1.4462124"
        height="1.4461316"
@@ -781,7 +781,7 @@
      transform="translate(0,91.439991)"
      id="g223">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect219"
        width="1.4462124"
        height="1.4461316"
@@ -801,7 +801,7 @@
      transform="translate(0,93.979991)"
      id="g229">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect225"
        width="1.4462124"
        height="1.4461316"
@@ -821,7 +821,7 @@
      transform="translate(0,96.519991)"
      id="g235">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect231"
        width="1.4462124"
        height="1.4461316"

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x40_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x40_P2.54mm_Vertical.svg
@@ -1,0 +1,858 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="2.6000724mm"
+   height="101.65999mm"
+   viewBox="0 0 2.6000723 101.65999"
+   id="svg4138"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="PinSocket_1x40_P2.54mm_Vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4140" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="90.509668"
+     inkscape:cx="-0.022097087"
+     inkscape:cy="4.7343009"
+     inkscape:document-units="px"
+     inkscape:current-layer="pin"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="true" />
+  <metadata
+     id="metadata4143">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="pin"
+     transform="translate(-1.001358e-5)">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4686"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4182"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <rect
+     style="opacity:0.95;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.983;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="origin"
+     width="1"
+     height="1"
+     x="1.2999901"
+     y="1.2999043" />
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,2.5399908)"
+     id="g13">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect9"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect11"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,5.0799908)"
+     id="g19">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect15"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect17"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,7.6199908)"
+     id="g25">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect21"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect23"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,10.159991)"
+     id="g31">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect27"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect29"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,12.699991)"
+     id="g37">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect33"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect35"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,15.239991)"
+     id="g43">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect39"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect41"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,17.779991)"
+     id="g49">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect45"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect47"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,20.319991)"
+     id="g55">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect51"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect53"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,22.859991)"
+     id="g61">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect57"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect59"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,25.399991)"
+     id="g67">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect63"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect65"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,27.939991)"
+     id="g73">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect69"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect71"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,30.479991)"
+     id="g79">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect75"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect77"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,33.019991)"
+     id="g85">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect81"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect83"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,35.559991)"
+     id="g91">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect87"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect89"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,38.099991)"
+     id="g97">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect93"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect95"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,40.639991)"
+     id="g103">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect99"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect101"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,43.179991)"
+     id="g109">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect105"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect107"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,45.719991)"
+     id="g115">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect111"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect113"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,48.259991)"
+     id="g121">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect117"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect119"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,50.799991)"
+     id="g127">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect123"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect125"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,53.339991)"
+     id="g133">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect129"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect131"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,55.879991)"
+     id="g139">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect135"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect137"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,58.419991)"
+     id="g145">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect141"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect143"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,60.959991)"
+     id="g151">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect147"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect149"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,63.499991)"
+     id="g157">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect153"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect155"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,66.039991)"
+     id="g163">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect159"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect161"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,68.579991)"
+     id="g169">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect165"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect167"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,71.119991)"
+     id="g175">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect171"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect173"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,73.659991)"
+     id="g181">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect177"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect179"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,76.199991)"
+     id="g187">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect183"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect185"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,78.739991)"
+     id="g193">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect189"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect191"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,81.279991)"
+     id="g199">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect195"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect197"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,83.819991)"
+     id="g205">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect201"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect203"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,86.359991)"
+     id="g211">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect207"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect209"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,88.899991)"
+     id="g217">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect213"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect215"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,91.439991)"
+     id="g223">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect219"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect221"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,93.979991)"
+     id="g229">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect225"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect227"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,96.519991)"
+     id="g235">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect231"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect233"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,99.059991)"
+     id="g241">
+    <rect
+       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect237"
+       width="1.4462124"
+       height="1.4461316"
+       x="0.57693499"
+       y="0.57693422" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.636875;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect239"
+       width="0.88712472"
+       height="0.88712502"
+       x="0.85647893"
+       y="0.8564375" />
+  </g>
+</svg>

--- a/KiCAD-base/Pin_Sockets/PinSocket_1x40_P2.54mm_Vertical.svg
+++ b/KiCAD-base/Pin_Sockets/PinSocket_1x40_P2.54mm_Vertical.svg
@@ -3,8 +3,8 @@
 
 <svg
    width="2.6000724mm"
-   height="101.65999mm"
-   viewBox="0 0 2.6000723 101.65999"
+   height="101.65998mm"
+   viewBox="0 0 2.6000723 101.65998"
    id="svg4138"
    version="1.1"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
@@ -54,7 +54,7 @@
      id="pin"
      transform="translate(-1.001358e-5)">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect4686"
        width="1.4462124"
        height="1.4461316"
@@ -74,14 +74,14 @@
      width="1"
      height="1"
      x="1.2999901"
-     y="1.2999043" />
+     y="1.299895" />
   <g
      inkscape:label="Vrstva 1"
      inkscape:groupmode="layer"
      transform="translate(0,2.5399908)"
      id="g13">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect9"
        width="1.4462124"
        height="1.4461316"
@@ -101,7 +101,7 @@
      transform="translate(0,5.0799908)"
      id="g19">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect15"
        width="1.4462124"
        height="1.4461316"
@@ -121,7 +121,7 @@
      transform="translate(0,7.6199908)"
      id="g25">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21"
        width="1.4462124"
        height="1.4461316"
@@ -141,7 +141,7 @@
      transform="translate(0,10.159991)"
      id="g31">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect27"
        width="1.4462124"
        height="1.4461316"
@@ -161,7 +161,7 @@
      transform="translate(0,12.699991)"
      id="g37">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect33"
        width="1.4462124"
        height="1.4461316"
@@ -181,7 +181,7 @@
      transform="translate(0,15.239991)"
      id="g43">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect39"
        width="1.4462124"
        height="1.4461316"
@@ -201,7 +201,7 @@
      transform="translate(0,17.779991)"
      id="g49">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect45"
        width="1.4462124"
        height="1.4461316"
@@ -221,7 +221,7 @@
      transform="translate(0,20.319991)"
      id="g55">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect51"
        width="1.4462124"
        height="1.4461316"
@@ -241,7 +241,7 @@
      transform="translate(0,22.859991)"
      id="g61">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect57"
        width="1.4462124"
        height="1.4461316"
@@ -261,7 +261,7 @@
      transform="translate(0,25.399991)"
      id="g67">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect63"
        width="1.4462124"
        height="1.4461316"
@@ -281,7 +281,7 @@
      transform="translate(0,27.939991)"
      id="g73">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect69"
        width="1.4462124"
        height="1.4461316"
@@ -301,7 +301,7 @@
      transform="translate(0,30.479991)"
      id="g79">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect75"
        width="1.4462124"
        height="1.4461316"
@@ -321,7 +321,7 @@
      transform="translate(0,33.019991)"
      id="g85">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect81"
        width="1.4462124"
        height="1.4461316"
@@ -341,7 +341,7 @@
      transform="translate(0,35.559991)"
      id="g91">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect87"
        width="1.4462124"
        height="1.4461316"
@@ -361,7 +361,7 @@
      transform="translate(0,38.099991)"
      id="g97">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect93"
        width="1.4462124"
        height="1.4461316"
@@ -381,7 +381,7 @@
      transform="translate(0,40.639991)"
      id="g103">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect99"
        width="1.4462124"
        height="1.4461316"
@@ -401,7 +401,7 @@
      transform="translate(0,43.179991)"
      id="g109">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect105"
        width="1.4462124"
        height="1.4461316"
@@ -421,7 +421,7 @@
      transform="translate(0,45.719991)"
      id="g115">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect111"
        width="1.4462124"
        height="1.4461316"
@@ -441,7 +441,7 @@
      transform="translate(0,48.259991)"
      id="g121">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect117"
        width="1.4462124"
        height="1.4461316"
@@ -461,7 +461,7 @@
      transform="translate(0,50.799991)"
      id="g127">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect123"
        width="1.4462124"
        height="1.4461316"
@@ -481,7 +481,7 @@
      transform="translate(0,53.339991)"
      id="g133">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect129"
        width="1.4462124"
        height="1.4461316"
@@ -501,7 +501,7 @@
      transform="translate(0,55.879991)"
      id="g139">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect135"
        width="1.4462124"
        height="1.4461316"
@@ -521,7 +521,7 @@
      transform="translate(0,58.419991)"
      id="g145">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect141"
        width="1.4462124"
        height="1.4461316"
@@ -541,7 +541,7 @@
      transform="translate(0,60.959991)"
      id="g151">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect147"
        width="1.4462124"
        height="1.4461316"
@@ -561,7 +561,7 @@
      transform="translate(0,63.499991)"
      id="g157">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect153"
        width="1.4462124"
        height="1.4461316"
@@ -581,7 +581,7 @@
      transform="translate(0,66.039991)"
      id="g163">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect159"
        width="1.4462124"
        height="1.4461316"
@@ -601,7 +601,7 @@
      transform="translate(0,68.579991)"
      id="g169">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect165"
        width="1.4462124"
        height="1.4461316"
@@ -621,7 +621,7 @@
      transform="translate(0,71.119991)"
      id="g175">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect171"
        width="1.4462124"
        height="1.4461316"
@@ -641,7 +641,7 @@
      transform="translate(0,73.659991)"
      id="g181">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect177"
        width="1.4462124"
        height="1.4461316"
@@ -661,7 +661,7 @@
      transform="translate(0,76.199991)"
      id="g187">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect183"
        width="1.4462124"
        height="1.4461316"
@@ -681,7 +681,7 @@
      transform="translate(0,78.739991)"
      id="g193">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect189"
        width="1.4462124"
        height="1.4461316"
@@ -701,7 +701,7 @@
      transform="translate(0,81.279991)"
      id="g199">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect195"
        width="1.4462124"
        height="1.4461316"
@@ -721,7 +721,7 @@
      transform="translate(0,83.819991)"
      id="g205">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect201"
        width="1.4462124"
        height="1.4461316"
@@ -741,7 +741,7 @@
      transform="translate(0,86.359991)"
      id="g211">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect207"
        width="1.4462124"
        height="1.4461316"
@@ -761,7 +761,7 @@
      transform="translate(0,88.899991)"
      id="g217">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect213"
        width="1.4462124"
        height="1.4461316"
@@ -781,7 +781,7 @@
      transform="translate(0,91.439991)"
      id="g223">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect219"
        width="1.4462124"
        height="1.4461316"
@@ -801,7 +801,7 @@
      transform="translate(0,93.979991)"
      id="g229">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect225"
        width="1.4462124"
        height="1.4461316"
@@ -821,7 +821,7 @@
      transform="translate(0,96.519991)"
      id="g235">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect231"
        width="1.4462124"
        height="1.4461316"
@@ -841,7 +841,7 @@
      transform="translate(0,99.059991)"
      id="g241">
     <rect
-       style="opacity:0.95;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:#141414;fill-opacity:1;fill-rule:nonzero;stroke:#141414;stroke-width:1.15385;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect237"
        width="1.4462124"
        height="1.4461316"

--- a/scripts/resize_canvas.sh
+++ b/scripts/resize_canvas.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-for i in `find . -name '*.svg'`; do echo "Processing $i"; inkscape --verb=FitCanvasToDrawing --verb=FileSave --verb=FileClose --verb=FileQuit $i ; done
+for i in `find . -name '*.svg'`; do echo "Processing $i"; inkscape $i -D -o $i ; done


### PR DESCRIPTION
The main change behind this PR is the addition of pin sockets. This is what the it looks like:
![image](https://user-images.githubusercontent.com/15680882/138550295-45abd815-9901-4a0e-88c2-e44a949367db.png)
And this is what it looks like on a board:
![image](https://user-images.githubusercontent.com/15680882/138570481-b79c1940-9a17-41a6-af4a-698d324d3653.png)


####Note:
For both this and the pin headers (which is what I based these drawings of), there is a 95% opacity on the plastic housing showing some of the PCB
![image](https://user-images.githubusercontent.com/15680882/138570506-bc31ef07-76b3-4901-9dfd-98e962bff440.png)
Is this intenional?


I also modified the resize script. Inkscape, as of >1.0, needs a GUI to be opened when executing the verb `FitCanvasToDrawing`. Instead I changed so that won't be an issue anymore.

I also modified the `Pin_Header_Straight_1x01.svg` base file so that the pin header group doesn't have a transform element to it. Otherwise when the pinheader generator script goes and generates the other headers, they are offset some 1000px down