### PR TITLE
Added RGB Wide and Staggered Models

### DIFF
--- a/KiCAD-base/LEDs/LED_D5.0mm-4_RGB_Staggered_Pins.svg
+++ b/KiCAD-base/LEDs/LED_D5.0mm-4_RGB_Staggered_Pins.svg
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="5mm"
+   height="5mm"
+   viewBox="0 0 5 5"
+   id="svg5567"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20, custom)"
+   sodipodi:docname="LED_D5.0mm-4_RGB_Staggered_Pins.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs5569">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6119">
+      <stop
+         style="stop-color:#b5e6f4;stop-opacity:1"
+         offset="0"
+         id="stop6121" />
+      <stop
+         style="stop-color:#9c9c9c;stop-opacity:1"
+         offset="1"
+         id="stop6123" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6119"
+       id="radialGradient6125"
+       cx="0"
+       cy="1052.3622"
+       fx="0"
+       fy="1052.3622"
+       r="2"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6129">
+      <rect
+         style="opacity:1;fill:#ff4321;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6131"
+         width="5.763474"
+         height="4.7717075"
+         x="-2.8443117"
+         y="1049.6301" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="64"
+     inkscape:cx="4.890625"
+     inkscape:cy="7.6171875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:object-nodes="false"
+     inkscape:snap-object-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid835"
+       originx="0.58578748"
+       originy="2.4122062"
+       units="in"
+       spacingx="0.25399999"
+       spacingy="0.25399999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5572">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(2.5,-1049.8622)">
+    <g
+       id="g6181"
+       transform="translate(0.50061553,-0.08777642)">
+      <rect
+         transform="rotate(-90)"
+         y="-1.5868281"
+         x="-1052.8622"
+         height="1.9"
+         width="1"
+         id="rect6158"
+         style="opacity:0.94;fill:#bfbfbf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="1051.8622"
+         x="0.56374156"
+         height="1"
+         width="0.91868997"
+         id="rect6160"
+         style="opacity:0.85;fill:#bfbfbf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         style="opacity:0.85"
+         transform="rotate(90,0,1052.3622)"
+         id="g6154">
+        <circle
+           style="opacity:1;fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path6115"
+           cx="0"
+           cy="1052.3622"
+           r="2.5"
+           clip-path="url(#clipPath6129)" />
+        <circle
+           style="opacity:1;fill:url(#radialGradient6125);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path6117"
+           cx="0"
+           cy="1052.3622"
+           r="2" />
+      </g>
+    </g>
+    <rect
+       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round"
+       id="origin"
+       width="1"
+       height="1"
+       x="-1.9142125"
+       y="1051.5125" />
+  </g>
+</svg>

--- a/KiCAD-base/LEDs/LED_D5.0mm-4_RGB_Wide_Pins.svg
+++ b/KiCAD-base/LEDs/LED_D5.0mm-4_RGB_Wide_Pins.svg
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="5mm"
+   height="5mm"
+   viewBox="0 0 5 5"
+   id="svg5567"
+   version="1.1"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20, custom)"
+   sodipodi:docname="LED_D5.0mm-4_RGB_Wide_Pins.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs5569">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6119">
+      <stop
+         style="stop-color:#b5e6f4;stop-opacity:1"
+         offset="0"
+         id="stop6121" />
+      <stop
+         style="stop-color:#9c9c9c;stop-opacity:1"
+         offset="1"
+         id="stop6123" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6119"
+       id="radialGradient6125"
+       cx="0"
+       cy="1052.3622"
+       fx="0"
+       fy="1052.3622"
+       r="2"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6129">
+      <rect
+         style="opacity:1;fill:#ff4321;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6131"
+         width="5.763474"
+         height="4.7717075"
+         x="-2.8443117"
+         y="1049.6301" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="64"
+     inkscape:cx="14.375"
+     inkscape:cy="9.0859375"
+     inkscape:document-units="in"
+     inkscape:current-layer="g6181"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:object-nodes="false"
+     inkscape:snap-object-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid835"
+       originx="0.58578748"
+       originy="2.4122062"
+       units="in"
+       spacingx="0.127"
+       spacingy="0.127" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5572">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Vrstva 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(2.5,-1049.8622)">
+    <rect
+       style="opacity:0.95;fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.127;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4933"
+       height="2.0319998"
+       x="-1052.5284"
+       y="-1.9142125"
+       transform="rotate(-90)"
+       width="0.5080362" />
+    <rect
+       style="opacity:0.95;fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:#cccccc;stroke-width:0.127;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4933-3"
+       height="1.9050001"
+       x="-1052.5284"
+       y="2.6577876"
+       transform="rotate(-90)"
+       width="0.50802046" />
+    <g
+       id="g6181"
+       transform="translate(1.32427,-0.0877938)">
+      <rect
+         transform="rotate(-90)"
+         y="-1.5868281"
+         x="-1052.8622"
+         height="1.9"
+         width="1"
+         id="rect6158"
+         style="opacity:1;fill:#bfbfbf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         y="1051.8622"
+         x="0.56374156"
+         height="1"
+         width="0.91868997"
+         id="rect6160"
+         style="opacity:1;fill:#bfbfbf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         style="opacity:0.85"
+         transform="rotate(90,0,1052.3622)"
+         id="g6154">
+        <circle
+           style="opacity:1;fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path6115"
+           cx="0"
+           cy="1052.3622"
+           r="2.5"
+           clip-path="url(#clipPath6129)" />
+        <circle
+           style="opacity:1;fill:url(#radialGradient6125);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path6117"
+           cx="0"
+           cy="1052.3622"
+           r="2" />
+      </g>
+    </g>
+    <rect
+       style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:round"
+       id="origin"
+       width="1"
+       height="1"
+       x="-1.914211"
+       y="1052.2745" />
+  </g>
+</svg>


### PR DESCRIPTION
This PR adds the following models:
- LED_D5.0mm-4_RGB_Wide_Pins.svg
  ![image](https://user-images.githubusercontent.com/15680882/160226784-0ea318f2-5e9c-4488-8e13-f0b761890d92.png)
- LED_D5.0mm-4_RGB_Staggered_Pins.svg
  ![image](https://user-images.githubusercontent.com/15680882/160226787-19c01843-cf29-4a58-9e2e-b3f3607a4047.png)
