### PR TITLE
Drawings for Electrolytic Capacitors

### DIFF
--- a/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P2.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P2.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="10.1mm"
+   height="10.1mm"
+   viewBox="0 0 10.1 10.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D10.0mm_P2.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 9.7484631,3.3398993 a 5,5 0 0 1 0,3.4202014 L 5.05,5.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="3.3333333" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="3.8"
+     y="5.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P3.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P3.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="10.1mm"
+   height="10.1mm"
+   viewBox="0 0 10.1 10.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D10.0mm_P3.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 9.7484631,3.3398993 a 5,5 0 0 1 0,3.4202014 L 5.05,5.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="3.3333333" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="3.3"
+     y="5.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P3.80mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P3.80mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="10.1mm"
+   height="10.1mm"
+   viewBox="0 0 10.1 10.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D10.0mm_P3.80mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 9.7484631,3.3398993 a 5,5 0 0 1 0,3.4202014 L 5.05,5.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="3.3333333" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="3.1500001"
+     y="5.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P5.00mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P5.00mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="10.1mm"
+   height="10.1mm"
+   viewBox="0 0 10.1 10.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D10.0mm_P5.00mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 9.7484631,3.3398993 a 5,5 0 0 1 0,3.4202014 L 5.05,5.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="3.3333333" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="2.55"
+     y="5.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P7.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D10.0mm_P7.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="10.1mm"
+   height="10.1mm"
+   viewBox="0 0 10.1 10.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D10.0mm_P7.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 9.7484631,3.3398993 a 5,5 0 0 1 0,3.4202014 L 5.05,5.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="3.3333333" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="5.0500002"
+     cy="5.0500002"
+     r="5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="1.3"
+     y="5.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D12.5mm_P2.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D12.5mm_P2.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="12.6mm"
+   height="12.6mm"
+   viewBox="0 0 12.6 12.6"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D12.5mm_P2.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="6.25" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 12.173079,4.1623741 a 6.25,6.25 0 0 1 0,4.2752518 L 6.3,6.3 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="4.1666665" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="6.25" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="5.0500002"
+     y="6.3000002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D12.5mm_P5.00mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D12.5mm_P5.00mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="12.6mm"
+   height="12.6mm"
+   viewBox="0 0 12.6 12.6"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D12.5mm_P5.00mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="6.25" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 12.173079,4.1623741 a 6.25,6.25 0 0 1 0,4.2752518 L 6.3,6.3 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="4.1666665" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="6.25" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="3.8"
+     y="6.3000002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D12.5mm_P7.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D12.5mm_P7.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="12.6mm"
+   height="12.6mm"
+   viewBox="0 0 12.6 12.6"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D12.5mm_P7.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="6.25" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 12.173079,4.1623741 a 6.25,6.25 0 0 1 0,4.2752518 L 6.3,6.3 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="4.1666665" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="6.3000002"
+     cy="6.3000002"
+     r="6.25" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="2.55"
+     y="6.3000002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D13.0mm_P2.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D13.0mm_P2.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="13.1mm"
+   height="13.1mm"
+   viewBox="0 0 13.1 13.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D13.0mm_P2.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="6.5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 12.658002,4.3268691 a 6.5,6.5 0 0 1 0,4.4462618 L 6.55,6.55 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="4.3333335" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="6.5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="5.3000002"
+     y="6.5500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D13.0mm_P5.00mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D13.0mm_P5.00mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="13.1mm"
+   height="13.1mm"
+   viewBox="0 0 13.1 13.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D13.0mm_P5.00mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="6.5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 12.658002,4.3268691 a 6.5,6.5 0 0 1 0,4.4462618 L 6.55,6.55 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="4.3333335" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="6.5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="4.0500002"
+     y="6.5500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D13.0mm_P7.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D13.0mm_P7.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="13.1mm"
+   height="13.1mm"
+   viewBox="0 0 13.1 13.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D13.0mm_P7.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="6.5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 12.658002,4.3268691 a 6.5,6.5 0 0 1 0,4.4462618 L 6.55,6.55 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="4.3333335" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="6.5500002"
+     cy="6.5500002"
+     r="6.5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="2.8"
+     y="6.5500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D14.0mm_P5.00mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D14.0mm_P5.00mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="14.1mm"
+   height="14.1mm"
+   viewBox="0 0 14.1 14.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D14.0mm_P5.00mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="7.0500002"
+     cy="7.0500002"
+     r="7" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 13.627848,4.655859 a 7,7 0 0 1 0,4.788282 L 7.05,7.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="7.0500002"
+     cy="7.0500002"
+     r="4.6666665" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="7.0500002"
+     cy="7.0500002"
+     r="7" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="4.5500002"
+     y="7.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D14.0mm_P7.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D14.0mm_P7.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="14.1mm"
+   height="14.1mm"
+   viewBox="0 0 14.1 14.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D14.0mm_P7.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="7.0500002"
+     cy="7.0500002"
+     r="7" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 13.627848,4.655859 a 7,7 0 0 1 0,4.788282 L 7.05,7.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="7.0500002"
+     cy="7.0500002"
+     r="4.6666665" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="7.0500002"
+     cy="7.0500002"
+     r="7" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="3.3"
+     y="7.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D16.0mm_P7.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D16.0mm_P7.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="16.1mm"
+   height="16.1mm"
+   viewBox="0 0 16.1 16.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D16.0mm_P7.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="8.0500002"
+     cy="8.0500002"
+     r="8" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 15.567541,5.3138389 a 8,8 0 0 1 0,5.4723221 L 8.05,8.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="8.0500002"
+     cy="8.0500002"
+     r="5.3333335" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="8.0500002"
+     cy="8.0500002"
+     r="8" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="4.3000002"
+     y="8.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D17.0mm_P7.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D17.0mm_P7.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="17.1mm"
+   height="17.1mm"
+   viewBox="0 0 17.1 17.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D17.0mm_P7.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="8.5500002"
+     cy="8.5500002"
+     r="8.5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 16.537387,5.6428288 a 8.5,8.5 0 0 1 0,5.8143422 L 8.55,8.55 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="8.5500002"
+     cy="8.5500002"
+     r="5.6666665" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="8.5500002"
+     cy="8.5500002"
+     r="8.5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="4.8000002"
+     y="8.5500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D18.0mm_P7.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D18.0mm_P7.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="18.1mm"
+   height="18.1mm"
+   viewBox="0 0 18.1 18.1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D18.0mm_P7.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="9.0500002"
+     cy="9.0500002"
+     r="9" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 17.507234,5.9718187 a 9,9 0 0 1 0,6.1563623 L 9.05,9.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="9.0500002"
+     cy="9.0500002"
+     r="6" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="9.0500002"
+     cy="9.0500002"
+     r="9" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="5.3000002"
+     y="9.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D4.0mm_P1.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D4.0mm_P1.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="4.0999999mm"
+   height="4.0999999mm"
+   viewBox="0 0 4.0999999 4.0999999"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D4.0mm_P1.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="2.05"
+     cy="2.05"
+     r="2" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 3.9293852,1.3659597 a 2,2 0 0 1 0,1.3680806 L 2.05,2.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="2.05"
+     cy="2.05"
+     r="1.3333334" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="2.05"
+     cy="2.05"
+     r="2" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="1.3"
+     y="2.05" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D4.0mm_P2.00mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D4.0mm_P2.00mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="4.0999999mm"
+   height="4.0999999mm"
+   viewBox="0 0 4.0999999 4.0999999"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D4.0mm_P2.00mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="2.05"
+     cy="2.05"
+     r="2" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 3.9293852,1.3659597 a 2,2 0 0 1 0,1.3680806 L 2.05,2.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="2.05"
+     cy="2.05"
+     r="1.3333334" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="2.05"
+     cy="2.05"
+     r="2" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="1.05"
+     y="2.05" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D5.0mm_P2.00mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D5.0mm_P2.00mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="5.0999999mm"
+   height="5.0999999mm"
+   viewBox="0 0 5.0999999 5.0999999"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D5.0mm_P2.00mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="2.55"
+     cy="2.55"
+     r="2.5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 4.8992316,1.6949496 a 2.5,2.5 0 0 1 0,1.7101008 L 2.55,2.55 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="2.55"
+     cy="2.55"
+     r="1.6666666" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="2.55"
+     cy="2.55"
+     r="2.5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="1.55"
+     y="2.55" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D5.0mm_P2.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D5.0mm_P2.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="5.0999999mm"
+   height="5.0999999mm"
+   viewBox="0 0 5.0999999 5.0999999"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D5.0mm_P2.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="2.55"
+     cy="2.55"
+     r="2.5" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 4.8992316,1.6949496 a 2.5,2.5 0 0 1 0,1.7101008 L 2.55,2.55 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="2.55"
+     cy="2.55"
+     r="1.6666666" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="2.55"
+     cy="2.55"
+     r="2.5" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="1.3"
+     y="2.55" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D6.3mm_P2.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D6.3mm_P2.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="6.4000001mm"
+   height="6.4000001mm"
+   viewBox="0 0 6.4000001 6.4000001"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D6.3mm_P2.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="3.2"
+     cy="3.2"
+     r="3.1500001" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 6.1600319,2.1226366 a 3.15,3.15 0 0 1 0,2.154727 L 3.2000001,3.2000001 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="3.2"
+     cy="3.2"
+     r="2.0999999" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="3.2"
+     cy="3.2"
+     r="3.1500001" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="1.95"
+     y="3.2" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D7.5mm_P2.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D7.5mm_P2.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="7.5999999mm"
+   height="7.5999999mm"
+   viewBox="0 0 7.5999999 7.5999999"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D7.5mm_P2.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="3.8"
+     cy="3.8"
+     r="3.75" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 7.3238473,2.5174245 a 3.75,3.75 0 0 1 0,2.565151 L 3.8,3.8 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="3.8"
+     cy="3.8"
+     r="2.5" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="3.8"
+     cy="3.8"
+     r="3.75" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="2.55"
+     y="3.8" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D8.0mm_P2.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D8.0mm_P2.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="8.1000004mm"
+   height="8.1000004mm"
+   viewBox="0 0 8.1000004 8.1000004"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D8.0mm_P2.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="4" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 7.8087705,2.6819194 a 4,4 0 0 1 0,2.7361612 L 4.05,4.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="2.6666667" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="4" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="2.8"
+     y="4.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D8.0mm_P3.50mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D8.0mm_P3.50mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="8.1000004mm"
+   height="8.1000004mm"
+   viewBox="0 0 8.1000004 8.1000004"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D8.0mm_P3.50mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="4" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 7.8087705,2.6819194 a 4,4 0 0 1 0,2.7361612 L 4.05,4.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="2.6666667" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="4" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="2.3"
+     y="4.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D8.0mm_P3.80mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D8.0mm_P3.80mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="8.1000004mm"
+   height="8.1000004mm"
+   viewBox="0 0 8.1000004 8.1000004"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D8.0mm_P3.80mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="4" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 7.8087705,2.6819194 a 4,4 0 0 1 0,2.7361612 L 4.05,4.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="2.6666667" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="4" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="2.1500001"
+     y="4.0500002" />
+</svg>

--- a/KiCAD-base/Capacitor_THT/CP_Radial_D8.0mm_P5.00mm.svg
+++ b/KiCAD-base/Capacitor_THT/CP_Radial_D8.0mm_P5.00mm.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="8.1000004mm"
+   height="8.1000004mm"
+   viewBox="0 0 8.1000004 8.1000004"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="CP_Radial_D8.0mm_P5.00mm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm" />
+  <circle
+     style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="blue_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="4" />
+  <path
+     style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="cathode_m"
+     d="m 7.8087705,2.6819194 a 4,4 0 0 1 0,2.7361612 L 4.05,4.05 Z" />
+  <circle
+     style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+     id="inner_white_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="2.6666667" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+     id="outline_c"
+     cx="4.0500002"
+     cy="4.0500002"
+     r="4" />
+  <rect
+     id="origin"
+     fill="#ff0000"
+     width="1"
+     height="1"
+     x="1.55"
+     y="4.0500002" />
+</svg>

--- a/scripts/base/ECapBase.svg
+++ b/scripts/base/ECapBase.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/), modified by Electro707 -->
+
+<svg
+   width="1mm"
+   height="1mm"
+   viewBox="0 0 1 1"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14, custom)"
+   sodipodi:docname="ECapBase.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="64"
+     inkscape:cx="6.9609375"
+     inkscape:cy="-2.7265625"
+     inkscape:window-width="2560"
+     inkscape:window-height="1390"
+     inkscape:window-x="1920"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1004"
+       spacingx="0.099999997"
+       spacingy="0.099999997"
+       empcolor="#3d52ff"
+       empopacity="0.30196078"
+       originx="0"
+       originy="0"
+       units="mm" />
+  </sodipodi:namedview>
+   <circle
+      style="fill:#5b5bff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+      id="blue_c"
+      cx="1.3000001"
+      cy="0"
+      r="2" />
+   <path
+      style="fill:#ababab;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+      id="cathode_m"
+      d="M 3.0320507,-1.0000001 A 2,2 0 0 1 3.0320508,1 L 1.3,0 Z" />
+   <circle
+      style="fill:#e5e5e5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-dasharray:none;stop-color:#000000"
+      id="inner_white_c"
+      cx="1.3"
+      cy="0"
+      r="1.5" />
+   <rect
+      id="origin"
+      fill="#ff0000"
+      width="1"
+      height="1"
+      x="0"
+      y="0" />
+   <circle
+      style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+      id="outline_c"
+      cx="1.3"
+      cy="0"
+      r="2" />
+</svg>

--- a/scripts/generate_electrolytic_cap.py
+++ b/scripts/generate_electrolytic_cap.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+"""
+  This program generates SMD passives (resistors, capacitors, etc).
+
+  This uses the base model found in base/passives.svg
+
+  This assumes that the part's origin is in the center of the part
+"""
+import sys
+import os
+from lxml import etree
+from copy import deepcopy
+import argparse
+import math
+
+def to_mm(i):
+  return i * 25.4
+
+def replace_keyvalue_value(svg_str, key, new_val):
+  n = svg_str.split(";")
+  n = [i.split(":") for i in n]
+  for i in n:
+    if i[0] == key:
+      i[1] = str(new_val)
+      break
+  n = [":".join(i) for i in n]
+  n = ";".join(n)
+  return n
+
+cap_sizes= [
+    {'d': 4.0, 'p': 1.5},
+    {'d': 4.0, 'p': 2.0},
+    {'d': 5.0, 'p': 2.0},
+    {'d': 5.0, 'p': 2.5},
+    {'d': 6.3, 'p': 2.5},
+    {'d': 7.5, 'p': 2.5},
+    {'d': 8.0, 'p': 2.5},
+    {'d': 8.0, 'p': 3.5},
+    {'d': 8.0, 'p': 3.8},
+    {'d': 8.0, 'p': 5.0},
+    {'d': 10.0, 'p': 2.5},
+    {'d': 10.0, 'p': 3.5},
+    {'d': 10.0, 'p': 3.8},
+    {'d': 10.0, 'p': 5.0},
+    {'d': 10.0, 'p': 7.5},
+    {'d': 12.5, 'p': 2.5},
+    {'d': 12.5, 'p': 5.0},
+    {'d': 12.5, 'p': 7.5},
+    {'d': 13.0, 'p': 2.5},
+    {'d': 13.0, 'p': 5.0},
+    {'d': 13.0, 'p': 7.5},
+    {'d': 14.0, 'p': 5.0},
+    {'d': 14.0, 'p': 7.5},
+    {'d': 16.0, 'p': 7.5},
+    {'d': 17.0, 'p': 7.5},
+    {'d': 18.0, 'p': 7.5},
+]
+
+cap_cathode_angle = math.radians(20)
+
+if __name__ == "__main__":
+
+  for size in cap_sizes:
+    document = etree.parse("base/ECapBase.svg")
+    root = document.getroot()
+
+    # Delete all inkscape grids and crap
+    p = root.find("{http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd}namedview")
+    root.remove(p)
+
+    # Remove the origin to add later. This is to place them above the pins
+    origin = root.find(".//*[@id='origin']")
+    root.remove(origin)
+
+    circle_fill = root.find(".//*[@id='blue_c']")
+    circle_cathode = root.find(".//*[@id='cathode_m']")
+    circle_white = root.find(".//*[@id='inner_white_c']")
+    circle_outline = root.find(".//*[@id='outline_c']")
+
+    # Set the circle sizes based off the size that we want
+    var_c_x_center = size['p']/2    # The center x location is in between the pins
+    var_radius = size['d'] / 2
+
+    circle_fill.attrib["r"] = "{}".format(var_radius)
+    circle_fill.attrib["cx"] = "{}".format(var_c_x_center)
+
+    circle_outline.attrib["r"] = "{}".format(var_radius)
+    circle_outline.attrib["cx"] = "{}".format(var_c_x_center)
+
+    circle_white.attrib["r"] = "{}".format(var_radius/1.5)
+    circle_white.attrib["cx"] = "{}".format(var_c_x_center)
+
+    circle_cathode.attrib["d"] = "M {},{} A {},{} 0 0 1 {},{} L {},0 Z".format(var_radius*math.cos(cap_cathode_angle)+var_c_x_center, -var_radius*math.sin(cap_cathode_angle), var_radius, var_radius, var_radius*math.cos(cap_cathode_angle)+var_c_x_center, var_radius*math.sin(cap_cathode_angle), var_c_x_center)
+
+    root.append(origin)
+    # Save
+    sn = "export/CP_Radial_D{:.1f}mm_P{:.2f}mm.svg".format(size['d'], size['p'])
+    if not os.path.isdir("export"):
+      os.mkdir("export")
+    document.write(sn)
+    os.system(f"inkscape {sn} -D -o {sn} ;")


### PR DESCRIPTION
This PR adds a script to generate several vertical electrolytic capacitors. The bellow drawing shows some of the already generated ones:
![image](https://user-images.githubusercontent.com/15680882/204122878-0b4bd9ab-c214-4d11-a43e-91385787dd80.png)

I marked this PR as a draft as I still need to add the rest of the capacitors, which is just a matter of me adding them to the script and testing them.

I might also change the color of the drawings, mainly the blue of the body. 

TODO:
- [ ] Add the rest of the vertical caps and test it
- [ ] Add symlinks for the "odds" ones that will probably work with an existing model (for example `Capacitor_THT:CP_Radial_D10.0mm_P2.50mm_P5.00mm`)
- [ ] Potentially change the cap's color