### PR TITLE
USB B Symbol Size Fix

### DIFF
--- a/KiCAD-base/Connector_USB/USB_B_OST_USB-B1HSxx_Horizontal.svg
+++ b/KiCAD-base/Connector_USB/USB_B_OST_USB-B1HSxx_Horizontal.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    sodipodi:docname="USB_B_OST_USB-B1HSxx_Horizontal.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20, custom)"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
    version="1.1"
    id="svg2"
-   width="1.0999955mm"
-   height="1.1000315mm"
-   viewBox="0 0 1.0999955 1.1000315"
+   width="16.75mm"
+   height="13.627mm"
+   viewBox="0 0 16.75 13.627"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -30,15 +30,15 @@
   <sodipodi:namedview
      inkscape:current-layer="g2463"
      inkscape:window-maximized="1"
-     inkscape:window-y="26"
-     inkscape:window-x="1920"
-     inkscape:cy="-12.71875"
-     inkscape:cx="7.375"
-     inkscape:zoom="16"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:cy="18.021576"
+     inkscape:cx="25.163597"
+     inkscape:zoom="13.511582"
      showgrid="true"
      id="namedview11"
-     inkscape:window-height="1390"
-     inkscape:window-width="2560"
+     inkscape:window-height="1678"
+     inkscape:window-width="3072"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0"
      guidetolerance="10"
@@ -48,17 +48,21 @@
      bordercolor="#666666"
      pagecolor="#7d7d7d"
      inkscape:pagecheckerboard="0"
-     inkscape:document-units="mm">
+     inkscape:document-units="mm"
+     inkscape:showpageshadow="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid822"
        units="mm"
        spacingx="0.1"
-       spacingy="0.1" />
+       spacingy="0.1"
+       originx="1.725"
+       originy="5.5635002" />
   </sodipodi:namedview>
   <g
      id="g2463"
-     transform="translate(-1.6,-4.8)">
+     transform="translate(0.125,0.76349999)">
     <rect
        style="fill:#e6e6e6;fill-rule:evenodd;stroke:#cccccc;stroke-width:0.127;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
        height="0.89999998"
@@ -74,7 +78,7 @@
        width="1.2000002"
        id="rect24-3" />
     <rect
-       style="fill:#d6dcdb;fill-opacity:1;fill-rule:evenodd;stroke:#99abb0;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       style="fill:#d6dcdb;fill-opacity:1;fill-rule:evenodd;stroke:#99abb0;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect879"
        width="16.5"
        height="12.1"
@@ -86,6 +90,6 @@
      id="origin"
      width="1"
      height="1"
-     x="-1.3877788e-17"
-     y="0" />
+     x="1.725"
+     y="5.5634999" />
 </svg>


### PR DESCRIPTION
This PR fixes the symbol I merged in #32, where I increased the svg document size to match the entire symbol.

This was important when highlighting that component, which uses the SVG size.